### PR TITLE
Start the system service using the unescaped arg

### DIFF
--- a/salt-proxy@.service
+++ b/salt-proxy@.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/salt-proxy --proxyid %I
+ExecStart=/usr/bin/salt-proxy --proxyid %i
 User=root
 Group=root
 Restart=always


### PR DESCRIPTION
`%I` escapes the instance name after `@`: see https://www.freedesktop.org/software/systemd/man/systemd.unit.html

For example, instead of `sng-a11-mgmt-sw2` is trying to start the process for `sng/a11/mgmt/sw2 `:

 ```
[root@saltstack1 cache]# systemctl status salt-proxy@sng-a11-mgmt-sw2 
● salt-proxy@sng-a11-mgmt-sw2.service - Salt proxy minion
   Loaded: loaded (/etc/systemd/system/salt-proxy@.service; disabled; vendor preset: disabled)
   Active: active (running) since Fri 2017-05-26 15:18:59 UTC; 618ms ago
 Main PID: 21990 (salt-proxy)
   CGroup: /system.slice/system-salt\x2dproxy.slice/salt-proxy@sng-a11-mgmt-sw2.service
           ├─21990 /usr/bin/python /usr/bin/salt-proxy -l debug --proxyid sng/a11/mgmt/sw2
           └─21999 /usr/bin/python /usr/bin/salt-proxy -l debug --proxyid sng/a11/mgmt/sw2
```