### PR TITLE
Remove explicit keepalive

### DIFF
--- a/proxy
+++ b/proxy
@@ -1,15 +1,5 @@
 master: localhost
 pki_dir: /etc/salt/pki/proxy
 cachedir: /var/cache/salt/proxy
-multiprocessing: False
-
-# to have mines with proxies, must add another config:
-# mine_enabled
-# ! new in 2016.3
-# see: https://github.com/saltstack/salt/issues/32022
+multiprocessing: false
 mine_enabled: True
-
-schedule:
-  napalm_keepalive:
-    function: napalm_proxy.reconnect
-    minutes: 1

--- a/proxy
+++ b/proxy
@@ -2,4 +2,4 @@ master: localhost
 pki_dir: /etc/salt/pki/proxy
 cachedir: /var/cache/salt/proxy
 multiprocessing: false
-mine_enabled: True
+mine_enabled: true


### PR DESCRIPTION
Now, by default enabled in Nitrogen:
https://docs.saltstack.com/en/develop/ref/configuration/proxy.html#std:conf_proxy-proxy_keep_alive